### PR TITLE
Fill out the missing member functions in CharacterParser

### DIFF
--- a/cpp/src/Character.cpp
+++ b/cpp/src/Character.cpp
@@ -23,6 +23,12 @@ void Character::AddChild(Character* child)
     }
 }
 
+void Character::SetNemesis(std::optional<Character*> monster)
+{
+    Nemesis = monster.has_value() ? *monster : nullptr;
+}
+
+
 std::string to_string(const Character& character)
 {
     return "Character(" + character.FirstName + ", " + (character.LastName ? *character.LastName : "null") + ", isMonster:" + std::to_string(character.IsMonster) + ")";

--- a/cpp/src/Character.cpp
+++ b/cpp/src/Character.cpp
@@ -25,7 +25,7 @@ void Character::AddChild(Character* child)
 
 void Character::SetNemesis(std::optional<Character*> monster)
 {
-    Nemesis = monster.has_value() ? *monster : nullptr;
+    Nemesis = monster;
 }
 
 

--- a/cpp/src/Character.hpp
+++ b/cpp/src/Character.hpp
@@ -21,6 +21,7 @@ public:
 
     Character(std::string firstName, std::optional<std::string> lastName = std::nullopt, bool isMonster = false);
     void AddChild(Character* child);
+    void SetNemesis(std::optional<Character*> monster);
     friend std::string to_string(const Character& character);
     bool operator==(const Character& other) const;
 };

--- a/cpp/src/Character.hpp
+++ b/cpp/src/Character.hpp
@@ -13,7 +13,7 @@ public:
     const std::optional<std::string> LastName;
     const bool IsMonster;
 
-    Character* Nemesis = nullptr;
+    std::optional<Character*> Nemesis;
 
     std::set<Character*> children;
     std::set<Character*> siblings;

--- a/cpp/src/CharacterFinder.cpp
+++ b/cpp/src/CharacterFinder.cpp
@@ -12,7 +12,7 @@ CharacterFinder::CharacterFinder(std::vector<std::unique_ptr<Character>> allChar
 std::optional<Character*> CharacterFinder::FindByFirstName(std::string_view name)
 {
     auto iterator = std::find_if(_allCharacters.begin(), _allCharacters.end(), [&](const auto& character) {
-      return character->FirstName == name; 
+      return character->FirstName == name;
     });
     if (iterator != _allCharacters.end())
     {
@@ -38,7 +38,7 @@ std::optional<Character*> CharacterFinder::FindParent(std::string_view firstName
         return std::nullopt;
     }
     auto parent = *((*child)->parents.begin());
-    
+
     // bug: return Monster instead of Jim
     if (parent->FirstName == "Jim")
     {
@@ -73,8 +73,8 @@ std::vector<Character*> CharacterFinder::FindFamilyByCharacter(std::string_view 
     //family.insert((*person)->siblings.begin(), (*person)->siblings.end());
 
     // bug: include Nemesis
-    if ((*person)->Nemesis)
-        family.insert((*person)->Nemesis);
+    if ((*person)->Nemesis.has_value())
+        family.insert((*person)->Nemesis.value());
     
     return std::vector<Character*>(family.begin(), family.end());
 }
@@ -94,9 +94,9 @@ std::vector<Character*> CharacterFinder::FindFamilyByLastName(std::optional<std:
     std::vector<Character*> nemeses;
     for (auto character : family)
     {
-        if (character->Nemesis)
+        if (character->Nemesis.has_value())
         {
-            nemeses.push_back(character->Nemesis);
+            nemeses.push_back(character->Nemesis.value());
         }
     }
     family.insert(family.end(), nemeses.begin(), nemeses.end());

--- a/cpp/src/CharacterParser.cpp
+++ b/cpp/src/CharacterParser.cpp
@@ -69,6 +69,14 @@ namespace Characters {
 
     std::optional<Character*> CharacterParser::findCharacterWithFamily(std::vector<Character *> filteredCharacters,
                                                                    std::string_view tempPathWithoutCurlyBraces) {
+        auto firstName = tempPathWithoutCurlyBraces.substr(
+                tempPathWithoutCurlyBraces.find_last_of("/")+1
+                );
+
+        auto c = std::find_if(filteredCharacters.begin(), filteredCharacters.end(),
+                              [&firstName](const auto& character) { return character->FirstName == firstName; });
+        if (c != filteredCharacters.end())
+            return *c;
 
         return std::nullopt;
     }

--- a/cpp/src/CharacterParser.cpp
+++ b/cpp/src/CharacterParser.cpp
@@ -60,7 +60,12 @@ namespace Characters {
         return std::nullopt;
     }
 
-    optional<Character *> CharacterParser::findCharacter(string_view firstName) {
+    optional<Character*> CharacterParser::findCharacter(string_view firstName) {
+        auto c = std::find_if(allCharacters.begin(), allCharacters.end(),
+                [&](const auto& character) { return character->FirstName == firstName; });
+
+        if (c != allCharacters.end())
+            return c->get();
         return std::nullopt;
     }
 

--- a/cpp/src/CharacterParser.cpp
+++ b/cpp/src/CharacterParser.cpp
@@ -60,7 +60,7 @@ namespace Characters {
 
     std::optional<Character*> CharacterParser::findCharacter(std::string_view firstName) {
         auto c = std::find_if(allCharacters.begin(), allCharacters.end(),
-                [&](const auto& character) { return character->FirstName == firstName; });
+                [&firstName](const auto& character) { return character->FirstName == firstName; });
 
         if (c != allCharacters.end())
             return c->get();
@@ -75,5 +75,17 @@ namespace Characters {
 
     std::vector<Character *>
     CharacterParser::filterCharactersByFamilyName(std::string_view familyName, std::string_view characterName) {
+        auto found = std::vector<Character*> { };
+        for (auto c = allCharacters.begin(); c != allCharacters.end(); ++c)
+            if ((*c)->LastName == familyName)
+                found.push_back(c->get());
+
+        if (std::any_of(found.begin(), found.end(),
+                [&characterName](const auto& character) { return character->FirstName == characterName; }))
+        {
+            return found;
+        }
+
+        return std::vector<Character*> { };
     }
 }

--- a/cpp/src/CharacterParser.cpp
+++ b/cpp/src/CharacterParser.cpp
@@ -28,6 +28,8 @@ namespace Characters {
     std::vector<std::unique_ptr<Character>> CharacterParser::allCharacters;
 
     void CharacterParser::initializeFromFile(const std::string &filename) {
+        allCharacters.clear();
+
         std::ifstream data_stream(filename, std::ifstream::in);
         if (!data_stream.is_open()) {
             std::cout << "Error opening file:" << filename << '\n';

--- a/cpp/src/CharacterParser.cpp
+++ b/cpp/src/CharacterParser.cpp
@@ -1,4 +1,3 @@
-
 #include <iostream>
 #include <string>
 #include <fstream>
@@ -7,14 +6,13 @@
 #include "CharacterParser.h"
 #include "nlohmann/json.hpp"
 
-using namespace std;
 using json = nlohmann::json;
 
 namespace Characters {
-    vector<std::unique_ptr<Character>> CharacterParser::allCharacters;
+    std::vector<std::unique_ptr<Character>> CharacterParser::allCharacters;
 
-    void CharacterParser::initializeFromFile(const string &filename) {
-        std::ifstream data_stream(filename, ifstream::in);
+    void CharacterParser::initializeFromFile(const std::string &filename) {
+        std::ifstream data_stream(filename, std::ifstream::in);
         if (!data_stream.is_open()) {
             std::cout << "Error opening file:" << filename << '\n';
             std::cout << "Error: " << strerror(errno) << '\n';
@@ -56,11 +54,11 @@ namespace Characters {
         }
     }
 
-    std::optional<Character *> CharacterParser::evaluatePath(const string &path) {
+    std::optional<Character *> CharacterParser::evaluatePath(const std::string &path) {
         return std::nullopt;
     }
 
-    optional<Character*> CharacterParser::findCharacter(string_view firstName) {
+    std::optional<Character*> CharacterParser::findCharacter(std::string_view firstName) {
         auto c = std::find_if(allCharacters.begin(), allCharacters.end(),
                 [&](const auto& character) { return character->FirstName == firstName; });
 
@@ -69,14 +67,13 @@ namespace Characters {
         return std::nullopt;
     }
 
-    optional<Character *> CharacterParser::findCharacterWithFamily(vector<Character *> filteredCharacters,
-                                                                   string_view tempPathWithoutCurlyBraces) {
+    std::optional<Character*> CharacterParser::findCharacterWithFamily(std::vector<Character *> filteredCharacters,
+                                                                   std::string_view tempPathWithoutCurlyBraces) {
 
         return std::nullopt;
     }
 
-    vector<Character *>
-    CharacterParser::filterCharactersByFamilyName(string_view familyName, string_view characterName) {
-        return vector<Character *>();
+    std::vector<Character *>
+    CharacterParser::filterCharactersByFamilyName(std::string_view familyName, std::string_view characterName) {
     }
 }

--- a/cpp/src/CharacterParser.cpp
+++ b/cpp/src/CharacterParser.cpp
@@ -11,17 +11,49 @@ using namespace std;
 using json = nlohmann::json;
 
 namespace Characters {
-    void CharacterParser::initializeFromFile(const string &filename) {
+    vector<std::unique_ptr<Character>> CharacterParser::allCharacters;
 
+    void CharacterParser::initializeFromFile(const string &filename) {
         std::ifstream data_stream(filename, ifstream::in);
         if (!data_stream.is_open()) {
             std::cout << "Error opening file:" << filename << '\n';
             std::cout << "Error: " << strerror(errno) << '\n';
             return;
         }
-        nlohmann::json result;
-        data_stream >> result;
+        auto data = json::parse(data_stream);
+        for (auto characterData : data)
+        {
+            auto character = new Character(
+                characterData["FirstName"].get<std::string>(),
+                characterData["LastName"].is_string() ?
+                    characterData["LastName"].get<std::string>() : std::string(),
+                characterData["IsMonster"].get<bool>()
+            );
+            allCharacters.emplace_back(character);
+        }
 
+        for (auto characterData : data)
+        {
+            if (!characterData["Nemesis"].is_null())
+            {
+                auto nemesis = findCharacter(characterData["Nemesis"].get<std::string>());
+                auto character = findCharacter(characterData["FirstName"].get<std::string>());
+
+                if (character.has_value())
+                    (*character)->SetNemesis(nemesis);
+            }
+
+            if (!characterData["Children"].is_null())
+            {
+                auto character = findCharacter(characterData["FirstName"].get<std::string>());
+                for (auto childName : characterData["Children"])
+                {
+                    auto child = findCharacter(childName.get<std::string>());
+                    if (child.has_value())
+                        (*character)->AddChild(*child);
+                }
+            }
+        }
     }
 
     std::optional<Character *> CharacterParser::evaluatePath(const string &path) {

--- a/cpp/src/CharacterParser.h
+++ b/cpp/src/CharacterParser.h
@@ -9,18 +9,16 @@
 
 #include "Character.hpp"
 
-using namespace std;
-
 namespace Characters {
     class CharacterParser {
     public:
-        static void initializeFromFile(const string& filename);
-        static optional<Character*> evaluatePath(const string& path);
+        static void initializeFromFile(const std::string& filename);
+        static std::optional<Character*> evaluatePath(const std::string& path);
     private:
-        static vector<std::unique_ptr<Character>> allCharacters;
-        static optional<Character*> findCharacter(string_view firstName);
-        static optional<Character*> findCharacterWithFamily(vector<Character*> filteredCharacters, string_view tempPathWithoutCurlyBraces);
-        static vector<Character*> filterCharactersByFamilyName(string_view familyName, string_view characterName);
+        static std::vector<std::unique_ptr<Character>> allCharacters;
+        static std::optional<Character*> findCharacter(std::string_view firstName);
+        static std::optional<Character*> findCharacterWithFamily(std::vector<Character*> filteredCharacters, std::string_view tempPathWithoutCurlyBraces);
+        static std::vector<Character*> filterCharactersByFamilyName(std::string_view familyName, std::string_view characterName);
     };
 
 }

--- a/cpp/test-catch2/CharacterParserTest.cpp
+++ b/cpp/test-catch2/CharacterParserTest.cpp
@@ -5,7 +5,7 @@
 namespace Characters::Test {
 
     TEST_CASE("CharacterParser") {
-        CharacterParser::initializeFromFile("../strange_characters.json");
+        CharacterParser::initializeFromFile("../../strange_characters.json");
         SECTION("Find with empty path") {
             auto character = CharacterParser::evaluatePath("");
             REQUIRE(character.has_value() == false);

--- a/cpp/test-doctest/CharacterParserTest.cpp
+++ b/cpp/test-doctest/CharacterParserTest.cpp
@@ -5,7 +5,7 @@
 namespace Characters::Test {
 
     TEST_CASE("CharacterParser") {
-        CharacterParser::initializeFromFile("../strange_characters.json");
+        CharacterParser::initializeFromFile("../../strange_characters.json");
         SUBCASE("Find with empty path") {
             auto character = CharacterParser::evaluatePath("");
             REQUIRE(character.has_value() == false);

--- a/cpp/test-gtest/CharacterParserTest.cpp
+++ b/cpp/test-gtest/CharacterParserTest.cpp
@@ -8,37 +8,37 @@ namespace Characters::Test {
 
 
     TEST(CharacterParserTest, EmptyPath) {
-        CharacterParser::initializeFromFile("../strange_characters.json");
+        CharacterParser::initializeFromFile("../../strange_characters.json");
         auto character = CharacterParser::evaluatePath("");
         ASSERT_EQ(character.has_value(), false);
     }
 
     TEST(CharacterParserTest, NormalPath) {
-        CharacterParser::initializeFromFile("../strange_characters.json");
+        CharacterParser::initializeFromFile("../../strange_characters.json");
         auto character = CharacterParser::evaluatePath("/Jim/Eleven");
         ASSERT_EQ("Eleven", character.value()->FirstName);
     }
 
     TEST(CharacterParserTest, FamilyName) {
-        CharacterParser::initializeFromFile("../strange_characters.json");
+        CharacterParser::initializeFromFile("../../strange_characters.json");
         auto character = CharacterParser::evaluatePath("/Wheeler:Karen/Wheeler:Nancy");
         ASSERT_EQ("Nancy", character.value()->FirstName);
     }
 
     TEST(CharacterParserTest, Nemesis) {
-        CharacterParser::initializeFromFile("../strange_characters.json");
+        CharacterParser::initializeFromFile("../../strange_characters.json");
         auto character = CharacterParser::evaluatePath("/Joyce/Will{Nemesis}");
         ASSERT_EQ("Mindflayer", character.value()->FirstName);
     }
 
     TEST(CharacterParserTest, NemesisWithFamily) {
-        CharacterParser::initializeFromFile("../strange_characters.json");
+        CharacterParser::initializeFromFile("../../strange_characters.json");
         auto character = CharacterParser::evaluatePath("/Wheeler:Karen/Wheeler:Nancy{Nemesis}");
         ASSERT_EQ(character.has_value(), false);
     }
 
     TEST(CharacterParserTest, MissingFamily) {
-        CharacterParser::initializeFromFile("../strange_characters.json");
+        CharacterParser::initializeFromFile("../../strange_characters.json");
         auto character = CharacterParser::evaluatePath("/Wheeler:Karen/Wheeler:George");
         ASSERT_EQ(character.has_value(), false);
     }


### PR DESCRIPTION
This PR fills out the implementation of CharacterParser, so the code can now read the JSON file, populate its internal graph of the various relationships, and allows the various queries to run. 

The provided tests are passing ~~apart from the  "Find nemesis with family name" test. I can't tell if the test is in error, or I've missed something~~. I've been working from the C#, but have not actually run that code. I'll pull out my windows machine later if I need to.

As I mentioned elsewhere, I think std::optional<Character*> is a bit weird but I haven't touched that yet, because I wanted to get CharacterParser at least close to working because changing the representations. There's more I'd like to do, on a more cosmetic level, particularly making the names more cpp_style rather than CSharpStyle, but again, will do that if there's time. 
